### PR TITLE
Fix deprecated method in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3",
         "inpsyde/php-coding-standards": "^0.13",
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^8.4"
     },
     "autoload": {
         "files": [

--- a/tests/cases/unit/Provider/SiteTest.php
+++ b/tests/cases/unit/Provider/SiteTest.php
@@ -137,7 +137,7 @@ class SiteTest extends ProviderTestCase
     {
         Monkey\Functions\when('is_multisite')->justReturn(false);
 
-        $this->expectExceptionMessageRegExp('/multisite/');
+        $this->expectExceptionMessageMatches('/multisite/');
         $this->factoryProvider(Provider\Site::class)();
     }
 }

--- a/tests/cases/unit/Provider/UserTest.php
+++ b/tests/cases/unit/Provider/UserTest.php
@@ -275,7 +275,7 @@ class UserTest extends ProviderTestCase
         $factory = $this->factoryProvider(Provider\User::class);
         $user = $factory();
 
-        $this->expectExceptionMessageRegExp('/WP_User::ID/');
+        $this->expectExceptionMessageMatches('/WP_User::ID/');
 
         $user->get('id');
     }

--- a/tests/cases/unit/ProvidersInitTest.php
+++ b/tests/cases/unit/ProvidersInitTest.php
@@ -20,7 +20,7 @@ class ProvidersInitTest extends TestCase
 {
     public function testWpMethodRequiresInitialization()
     {
-        $this->expectExceptionMessageRegExp('/initialized/');
+        $this->expectExceptionMessageMatches('/initialized/');
 
         $provider = new Providers(Factory::create());
         $provider->wp();
@@ -28,7 +28,7 @@ class ProvidersInitTest extends TestCase
 
     public function testCallMethodRequiresInitialization()
     {
-        $this->expectExceptionMessageRegExp('/initialized/');
+        $this->expectExceptionMessageMatches('/initialized/');
 
         $provider = new Providers(Factory::create());
         /** @noinspection PhpUndefinedMethodInspection */


### PR DESCRIPTION
The method `expectExceptionMessageRegExp` is deprecated and has been replaced with `expectExceptionMessageMatches` from version 8.4. It will be removed from version 9.

See [https://github.com/sebastianbergmann/phpunit/blob/8.4.0/src/Framework/TestCase.php#L503](https://github.com/sebastianbergmann/phpunit/blob/8.4.0/src/Framework/TestCase.php#L503)