### PR TITLE
Mock WordPress functions with the same object of the provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3",
         "inpsyde/php-coding-standards": "^0.13",
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^8.4"
     },
     "autoload": {
         "files": [

--- a/src/Provider/User.php
+++ b/src/Provider/User.php
@@ -203,7 +203,7 @@ class User extends FunctionMockerProvider
     ];
 
     /**
-     * @var array[]
+     * @var \WP_User[]
      */
     private $users = [];
 
@@ -360,7 +360,6 @@ class User extends FunctionMockerProvider
 
         $user->shouldReceive('get_site_id')->andReturn($siteId)->byDefault();
 
-        $this->saveUser($get, (int)$siteId, $user);
         $this->mockFunctions();
 
         $user->shouldReceive('__monkeyMakeCurrent')
@@ -372,6 +371,8 @@ class User extends FunctionMockerProvider
                     return $user;
                 }
             );
+
+        $this->saveUser($user);
 
         return $user;
     }
@@ -410,19 +411,11 @@ class User extends FunctionMockerProvider
     }
 
     /**
-     * @param array $properties
-     * @param int $siteId
      * @param \WP_User $user
      */
-    private function saveUser(array $properties, int $siteId, \WP_User $user)
+    private function saveUser(\WP_User $user)
     {
-        $updatedProps = $properties;
-        $updatedProps['site_id'] = $siteId;
-        $updatedProps['allcaps'] = $user->allcaps;
-        $updatedProps['roles'] = $user->roles;
-        $updatedProps['user_level'] = $user->user_level;
-
-        $this->users[$user->ID] = $updatedProps;
+        $this->users[$user->ID] = $user;
     }
 
     /**
@@ -448,7 +441,7 @@ class User extends FunctionMockerProvider
                         return false;
                     }
 
-                    return $this->__invoke($this->users[(int)$userId]);
+                    return $this->users[(int)$userId];
                 }
             );
 
@@ -477,7 +470,7 @@ class User extends FunctionMockerProvider
                         return false;
                     }
 
-                    return $this->__invoke($this->users[(int)$id]);
+                    return $this->users[(int)$id];
                 }
             );
 
@@ -494,7 +487,7 @@ class User extends FunctionMockerProvider
                         return false;
                     }
 
-                    $caps = $this->users[(int)$userId]['allcaps'];
+                    $caps = $this->users[(int)$userId]->allcaps;
 
                     return !empty($caps[$cap]);
                 }

--- a/tests/cases/functional/BrainFakerTest.php
+++ b/tests/cases/functional/BrainFakerTest.php
@@ -70,6 +70,15 @@ class BrainFakerTest extends FunctionalTestCase
         static::assertSame('Bad user', $this->productionCode(123));
     }
 
+    public function testReturnedUsedIsTheSameMockedOne()
+    {
+        $this->wpFaker->post(['id' => 123, 'author' => 456]);
+        $mockedUser = $this->wpFaker->user(['id' => 456, 'role' => 'editor'])->__monkeyMakeCurrent();
+
+        static::assertSame($mockedUser, get_userdata(456));
+        static::assertSame($mockedUser, get_user_by('ID', 456));
+    }
+
     public function testWithoutBrainFaker()
     {
         $post = \Mockery::mock(\WP_Post::class);

--- a/tests/cases/unit/Provider/SiteTest.php
+++ b/tests/cases/unit/Provider/SiteTest.php
@@ -137,7 +137,7 @@ class SiteTest extends ProviderTestCase
     {
         Monkey\Functions\when('is_multisite')->justReturn(false);
 
-        $this->expectExceptionMessageRegExp('/multisite/');
+        $this->expectExceptionMessageMatches('/multisite/');
         $this->factoryProvider(Provider\Site::class)();
     }
 }

--- a/tests/cases/unit/Provider/UserTest.php
+++ b/tests/cases/unit/Provider/UserTest.php
@@ -275,7 +275,7 @@ class UserTest extends ProviderTestCase
         $factory = $this->factoryProvider(Provider\User::class);
         $user = $factory();
 
-        $this->expectExceptionMessageRegExp('/WP_User::ID/');
+        $this->expectExceptionMessageMatches('/WP_User::ID/');
 
         $user->get('id');
     }

--- a/tests/cases/unit/ProvidersInitTest.php
+++ b/tests/cases/unit/ProvidersInitTest.php
@@ -20,7 +20,7 @@ class ProvidersInitTest extends TestCase
 {
     public function testWpMethodRequiresInitialization()
     {
-        $this->expectExceptionMessageRegExp('/initialized/');
+        $this->expectExceptionMessageMatches('/initialized/');
 
         $provider = new Providers(Factory::create());
         $provider->wp();
@@ -28,7 +28,7 @@ class ProvidersInitTest extends TestCase
 
     public function testCallMethodRequiresInitialization()
     {
-        $this->expectExceptionMessageRegExp('/initialized/');
+        $this->expectExceptionMessageMatches('/initialized/');
 
         $provider = new Providers(Factory::create());
         /** @noinspection PhpUndefinedMethodInspection */


### PR DESCRIPTION
At the current moment, a mocked object is returned by the provider, when you call it. However, a new mocked object is generated for each stubbed WordPress function. This doesn't allow to rely on the parameters checking, while testing expectations.

I've fixed it for the `User` provider only for now, if the solution makes sense I can implement the solution for the other providers as well.

Watch out, this PR also include the commit already present in [this other one](https://github.com/Brain-WP/BrainFaker/pull/5), otherwise I'd not be able to run tests.

This is the code with which you can reproduce the problem:

```
<?php

use Brain\Monkey;
use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
use PHPUnit\Framework\TestCase as FrameworkTestCase;

class UserParser {
    public function parse(\WP_User $wpUser): string {
        return 'pointless-value';
    }
}

class PostAuthorFetcher {

    /**
     * @var UserParser
     */
    private $userParser;

    public function __construct(UserParser $userParser) {

        $this->userParser = $userParser;
    }

    public function fetchAuthor(\WP_Post $wpPost) {
        return $this->userParser->parse(get_userdata($wpPost->post_author));
    }
}

class FakerTest extends FrameworkTestCase {

    /**
     * @var \Brain\Faker\Providers
     */
    protected $wpFaker;

    /**
     * @return void
     */
    protected function setUp(): void
    {
        parent::setUp();
        Monkey\setUp();

        $this->wpFaker = \Brain\faker()->wp();
    }

    /**
     * @return void
     */
    protected function tearDown(): void
    {
        Monkey\tearDown();
        parent::tearDown();
    }

    public function testFakerStub()
    {
        $mockPost = $this->wpFaker->post(['post_author' => 10]);

        $mockUser = $this->wpFaker->user(['ID' => 10]);

        $mockUserParser = \Mockery::mock(UserParser::class);
        $mockUserParser->expects('parse')
            ->with($mockUser)
            ->andReturn('pointless-value');

        $postAuthorFetcher = new PostAuthorFetcher($mockUserParser);

        $postAuthorFetcher->fetchAuthor($mockPost);
    }
}
```